### PR TITLE
Adding media_suffix config.ini option. This option enables a suffix o…

### DIFF
--- a/simplemenu/output/Bittboy/config/config.ini
+++ b/simplemenu/output/Bittboy/config/config.ini
@@ -1,5 +1,6 @@
 [GENERAL]
 media_folder = media
+media_suffix =
 logging_enabled = 0
 cache = 1
 

--- a/simplemenu/output/PG2/config/config.ini
+++ b/simplemenu/output/PG2/config/config.ini
@@ -1,5 +1,6 @@
 [GENERAL]
 media_folder = media
+media_suffix =
 logging_enabled = 0
 cache = 1
 

--- a/simplemenu/output/RFW/config/config.ini
+++ b/simplemenu/output/RFW/config/config.ini
@@ -1,5 +1,6 @@
 [GENERAL]
 media_folder = media
+media_suffix =
 logging_enabled = 0
 cache = 1
 

--- a/simplemenu/output/RG-350-BETA/config/config.ini
+++ b/simplemenu/output/RG-350-BETA/config/config.ini
@@ -1,5 +1,6 @@
 [GENERAL]
 media_folder = media
+media_suffix =
 logging_enabled = 0
 cache = 1
 

--- a/simplemenu/output/RG-350/config/config.ini
+++ b/simplemenu/output/RG-350/config/config.ini
@@ -1,5 +1,6 @@
 [GENERAL]
 media_folder = media
+media_suffix =
 logging_enabled = 0
 cache = 1
 

--- a/simplemenu/src/headers/globals.h
+++ b/simplemenu/src/headers/globals.h
@@ -75,6 +75,7 @@ extern int SHUTDOWN_OPTION;
 extern int AUTO_HIDE_LOGOS_OPTION;
 extern int ITEMS_PER_PAGE_OPTION;
 extern char mediaFolder[1000];
+extern char mediaSuffix[1000];
 extern int stripGames;
 extern int shutDownEnabled;
 extern int selectedShutDownOption;

--- a/simplemenu/src/logic/config.c
+++ b/simplemenu/src/logic/config.c
@@ -613,6 +613,9 @@ void loadConfig() {
 	value = ini_get(config, "GENERAL", "media_folder");
 	strcpy(mediaFolder,value);
 
+	value = ini_get(config, "GENERAL", "media_suffix");
+	if (value!=NULL) strcpy(mediaSuffix,value);
+
 	value = ini_get(config, "GENERAL", "logging_enabled");
 
 	if (atoifgl(value)==1) {

--- a/simplemenu/src/logic/globals.c
+++ b/simplemenu/src/logic/globals.c
@@ -75,6 +75,7 @@ typedef struct thread_picture {
  int AUTO_HIDE_LOGOS_OPTION;
  int ITEMS_PER_PAGE_OPTION;
  char mediaFolder[1000];
+ char mediaSuffix[1000];
  int stripGames;
  int shutDownEnabled;
  int selectedShutDownOption;

--- a/simplemenu/src/logic/screen.c
+++ b/simplemenu/src/logic/screen.c
@@ -288,6 +288,9 @@ void displayGamePicture(struct Rom *rom) {
 	strcat(pictureWithFullPath,mediaFolder);
 	strcat(pictureWithFullPath,"/");
 	strcat(pictureWithFullPath,tempGameName);
+	if ((mediaSuffix!=NULL) && (strlen(mediaSuffix)>0)) {
+                strcat(pictureWithFullPath,mediaSuffix);
+    }
 	strcat(pictureWithFullPath,".png");
 	displayBackgroundPicture();
 	if (rom==NULL) {
@@ -404,6 +407,9 @@ void displayGamePictureInMenu(struct Rom *rom) {
 	strcat(pictureWithFullPath,mediaFolder);
 	strcat(pictureWithFullPath,"/");
 	strcat(pictureWithFullPath,tempGameName);
+	if ((mediaSuffix!=NULL) && (strlen(mediaSuffix)>0)) {
+		strcat(pictureWithFullPath,mediaSuffix);
+	}
 	strcat(pictureWithFullPath,".png");
 	if (rom!=NULL) {
 		char *tempDisplayName = getFileNameOrAlias(rom);


### PR DESCRIPTION
Suggested change to allow image files to have a suffix as is common for other systems. This would help people maintain one set of roms and images across devices (use images scraped from another device, i.e. an RG351P, RG351V, ...)

For example, SuperMarioWorld.zip could use the media file SuperMarioWorld-image.png. 

Just set "media_suffix = -image" in config.ini. 

If media_suffix is not in config.ini or not set, no media suffix is applied.
