### PR TITLE
Add device list for ABXY controls

### DIFF
--- a/simplemenu/output/Bittboy/config/config.ini
+++ b/simplemenu/output/Bittboy/config/config.ini
@@ -10,10 +10,12 @@ hdmi_width = 640
 hdmi_height = 480
 
 [CONTROLS]
+; ABXY controls for: PocketGo, Q20 Mini, Q90, V90
 ;A = 308
 ;B = 306
 ;X = 304
 ;Y = 32
+; ABXY controls for: Bittboy
 A = 306
 B = 32
 X = 308


### PR DESCRIPTION
Add a list of reference devices for ABXY controls so that it's easier for the user to identify which to use.