### PR TITLE
Fix: No battery icon below batteryNow 3600 (Bittboy)

### DIFF
--- a/simplemenu/src/logic/control.c
+++ b/simplemenu/src/logic/control.c
@@ -232,10 +232,12 @@ void launchGame(struct Rom *rom) {
 	if (favoritesSectionSelected && favoritesSize > 0) {
 		struct Favorite favorite = favorites[CURRENT_GAME_NUMBER];
 		strcpy(tempExec,favorite.emulatorFolder);
-		strcat(tempExec,favorite.executable);
+		char executableFileWithExtra[100];
+		strcpy(executableFileWithExtra, favorite.executable);
+		strcat(tempExec, strtok(executableFileWithExtra, " "));
 		file = fopen(tempExec, "r");
 		if (!file&&strstr(tempExec,"#")==NULL) {
-			strcpy(error,favorite.executable);
+			strcpy(error, executableFileWithExtra);
 			strcat(error,"-NOT FOUND");
 			generateError(error,0);
 			return;

--- a/simplemenu/src/logic/system_logic_bittboy.c
+++ b/simplemenu/src/logic/system_logic_bittboy.c
@@ -3,9 +3,12 @@
 #include <sys/mman.h>
 #include <SDL/SDL_timer.h>
 #include <unistd.h>
+#include <math.h>
 
 #include "../headers/globals.h"
 #include "../headers/system_logic.h"
+
+#define BAT_CRITICAL 3330
 
 volatile uint32_t *memregs;
 
@@ -385,23 +388,18 @@ void cycleFrequencies() {
 }
 
 int getBatteryLevel() {
-	int max_voltage = 4050;
-	int min_voltage = 3480;
+	// int max_voltage = 4050;
+	// int min_voltage = 3480;
 	int voltage_now;
-	int total;
+	// int total;
 	FILE *f = fopen("/sys/class/power_supply/miyoo-battery/voltage_now", "r");
 	fscanf(f, "%i", &voltage_now);
 	fclose(f);
 
 //	total = (voltage_now - min_voltage) * 6 / (max_voltage - min_voltage);
-	if (voltage_now > 4050) return 6;
-	if (voltage_now > 4000) return 5;
-	if (voltage_now > 3900) return 4;
-	if (voltage_now > 3800) return 3;
-	if (voltage_now > 3700) return 2;
-	if (voltage_now > 3520) return 1;
-//	if (total>5) {
-//		return 5;
-//	}
-//	return total;
+	return floorf((voltage_now - BAT_CRITICAL) / 180.00) + 1;
+	//	if (total>5) {
+	//		return 5;
+	//	}
+	//	return total;
 }


### PR DESCRIPTION
Battery icon disappears when battery reading is below 3600. 